### PR TITLE
Remove dependabot since there's no package.json

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "weekly"


### PR DESCRIPTION
Errors from Insights > Dependency graph > Dependabot:

<img width="923" alt="Screenshot 2024-11-14 at 11 24 35 AM" src="https://github.com/user-attachments/assets/5c2eb00c-c0f2-4b11-a9df-abbb6e3dc095">
